### PR TITLE
GDSC 테마 완성

### DIFF
--- a/example/opacity_control/lib/main.dart
+++ b/example/opacity_control/lib/main.dart
@@ -54,7 +54,7 @@ class _OpacitySliderExampleState extends State<OpacitySliderExample> {
                     ElevatedButton(
                       onPressed: () {
                         setState(() {
-                          theme.theme = GDSCColorTheme.blue;
+                          theme.current = GDSCColorTheme.blue;
                         });
                       },
                       child: const Text("Blue"),
@@ -62,7 +62,7 @@ class _OpacitySliderExampleState extends State<OpacitySliderExample> {
                     ElevatedButton(
                       onPressed: () {
                         setState(() {
-                          theme.theme = GDSCColorTheme.green;
+                          theme.current = GDSCColorTheme.green;
                         });
                       },
                       child: const Text("Green"),
@@ -70,7 +70,7 @@ class _OpacitySliderExampleState extends State<OpacitySliderExample> {
                     ElevatedButton(
                       onPressed: () {
                         setState(() {
-                          theme.theme = GDSCColorTheme.yellow;
+                          theme.current = GDSCColorTheme.yellow;
                         });
                       },
                       child: const Text("Yellow"),
@@ -78,7 +78,7 @@ class _OpacitySliderExampleState extends State<OpacitySliderExample> {
                     ElevatedButton(
                       onPressed: () {
                         setState(() {
-                          theme.theme = GDSCColorTheme.red;
+                          theme.current = GDSCColorTheme.red;
                         });
                       },
                       child: const Text("Red"),

--- a/example/opacity_control/lib/main.dart
+++ b/example/opacity_control/lib/main.dart
@@ -36,7 +36,7 @@ class _OpacitySliderExampleState extends State<OpacitySliderExample> {
                 Text(
                   "Opacity: ${(_opacity * 100).round()}%",
                   style: TextStyle(
-                    color: theme.contentColors.gray.a3,
+                    color: theme.colors.content.gray.a3,
                   ),
                 ),
                 Slider(

--- a/example/opacity_control/lib/main.dart
+++ b/example/opacity_control/lib/main.dart
@@ -11,27 +11,32 @@ void main() {
 }
 
 class OpacitySliderExample extends StatefulWidget {
+
   @override
   _OpacitySliderExampleState createState() => _OpacitySliderExampleState();
 }
 
 class _OpacitySliderExampleState extends State<OpacitySliderExample> {
   double _opacity = 0.5;
+  GDSCTheme theme = GDSCTheme(
+    currentTheme: GDSCColorTheme.yellow,
+  );
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: theme.getTheme(),
       home: Scaffold(
         body: Center(
           child: Container(
-            color: GDSCPalette.blue500.withOpacity(_opacity),
+            color: theme.getTheme().primaryColor.withOpacity(_opacity),
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Text(
                   "Opacity: ${(_opacity * 100).round()}%",
                   style: TextStyle(
-                    color: GDSCPalette.black,
+                    color: theme.colors.background.primary.solid,
                   ),
                 ),
                 Slider(
@@ -41,8 +46,45 @@ class _OpacitySliderExampleState extends State<OpacitySliderExample> {
                       _opacity = value;
                     });
                   },
-                  activeColor: GDSCPalette.yellow500,
+                  // activeColor: theme.getTheme().primaryColor,
                 ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          theme.theme = GDSCColorTheme.blue;
+                        });
+                      },
+                      child: const Text("Blue"),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          theme.theme = GDSCColorTheme.green;
+                        });
+                      },
+                      child: const Text("Green"),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          theme.theme = GDSCColorTheme.yellow;
+                        });
+                      },
+                      child: const Text("Yellow"),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          theme.theme = GDSCColorTheme.red;
+                        });
+                      },
+                      child: const Text("Red"),
+                    ),
+                  ],
+                )
               ],
             ),
           ),

--- a/example/opacity_control/lib/main.dart
+++ b/example/opacity_control/lib/main.dart
@@ -36,7 +36,7 @@ class _OpacitySliderExampleState extends State<OpacitySliderExample> {
                 Text(
                   "Opacity: ${(_opacity * 100).round()}%",
                   style: TextStyle(
-                    color: theme.colors.background.primary.solid,
+                    color: theme.contentColors.gray.a3,
                   ),
                 ),
                 Slider(

--- a/lib/gdsc_ys_color.dart
+++ b/lib/gdsc_ys_color.dart
@@ -1,5 +1,5 @@
 library gdsc_ys_color;
 
 export 'src/enum/index.dart' show GDSCColorTheme;
-export 'src/palette/palette.style.dart' show GDSCPalette;
+export 'src/palette/index.dart' show GDSCPalette;
 export 'src/theme/index.dart' show GDSCTheme;

--- a/lib/gdsc_ys_color.dart
+++ b/lib/gdsc_ys_color.dart
@@ -1,3 +1,5 @@
 library gdsc_ys_color;
 
-export 'src/palette.style.dart' show GDSCPalette;
+export 'src/enum/index.dart' show GDSCColorTheme;
+export 'src/palette/palette.style.dart' show GDSCPalette;
+export 'src/theme/index.dart' show GDSCTheme;

--- a/lib/src/content/index.dart
+++ b/lib/src/content/index.dart
@@ -1,23 +1,18 @@
-
-
 import 'dart:ui';
 
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
 class GrayScaleColor {
-
-    final Color a1 = GDSCPalette.gray100;
-    final Color a2 = GDSCPalette.gray300.withOpacity(0.84);
-    final Color a3 = GDSCPalette.gray400;
-    final Color a4 = GDSCPalette.gray600;
-    final Color a5 = GDSCPalette.gray800;
-    final Color a6 = GDSCPalette.gray1000.withOpacity(0.84);
-    final Color a7 = GDSCPalette.gray1000;
-
+  final Color a1 = GDSCPalette.gray100;
+  final Color a2 = GDSCPalette.gray300.withOpacity(0.84);
+  final Color a3 = GDSCPalette.gray400;
+  final Color a4 = GDSCPalette.gray600;
+  final Color a5 = GDSCPalette.gray800;
+  final Color a6 = GDSCPalette.gray1000.withOpacity(0.84);
+  final Color a7 = GDSCPalette.gray1000;
 }
 
 class TintColor {
-
   final Color a1;
   final Color a2;
   final Color a3;
@@ -27,35 +22,33 @@ class TintColor {
     required this.a2,
     required this.a3,
   });
-
 }
 
 class TintColors {
-
   final TintColor magenta = TintColor(
     a1: GDSCPalette.magenta300,
     a2: GDSCPalette.magenta500,
     a3: GDSCPalette.magenta700,
   );
-  
+
   final TintColor cyan = TintColor(
     a1: GDSCPalette.cyan300,
     a2: GDSCPalette.cyan500,
     a3: GDSCPalette.cyan700,
   );
-  
+
   final TintColor orange = TintColor(
     a1: GDSCPalette.orange300,
     a2: GDSCPalette.orange500,
     a3: GDSCPalette.orange700,
   );
-  
+
   final TintColor purple = TintColor(
     a1: GDSCPalette.purple300,
     a2: GDSCPalette.purple500,
     a3: GDSCPalette.purple700,
   );
-  
+
   final TintColor blue = TintColor(
     a1: GDSCPalette.blue300.withOpacity(0.84),
     a2: GDSCPalette.blue500,
@@ -79,14 +72,11 @@ class TintColors {
     a2: GDSCPalette.green500,
     a3: GDSCPalette.green700,
   );
-
 }
 
 class GDSCContentColors {
-
   final white = GDSCPalette.white;
   final black = GDSCPalette.black;
   final gray = GrayScaleColor();
   final tint = TintColors();
-
 }

--- a/lib/src/content/index.dart
+++ b/lib/src/content/index.dart
@@ -1,0 +1,92 @@
+
+
+import 'dart:ui';
+
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class GrayScaleColor {
+
+    final Color a1 = GDSCPalette.gray100;
+    final Color a2 = GDSCPalette.gray300.withOpacity(0.84);
+    final Color a3 = GDSCPalette.gray400;
+    final Color a4 = GDSCPalette.gray600;
+    final Color a5 = GDSCPalette.gray800;
+    final Color a6 = GDSCPalette.gray1000.withOpacity(0.84);
+    final Color a7 = GDSCPalette.gray1000;
+
+}
+
+class TintColor {
+
+  final Color a1;
+  final Color a2;
+  final Color a3;
+
+  TintColor({
+    required this.a1,
+    required this.a2,
+    required this.a3,
+  });
+
+}
+
+class TintColors {
+
+  final TintColor magenta = TintColor(
+    a1: GDSCPalette.magenta300,
+    a2: GDSCPalette.magenta500,
+    a3: GDSCPalette.magenta700,
+  );
+  
+  final TintColor cyan = TintColor(
+    a1: GDSCPalette.cyan300,
+    a2: GDSCPalette.cyan500,
+    a3: GDSCPalette.cyan700,
+  );
+  
+  final TintColor orange = TintColor(
+    a1: GDSCPalette.orange300,
+    a2: GDSCPalette.orange500,
+    a3: GDSCPalette.orange700,
+  );
+  
+  final TintColor purple = TintColor(
+    a1: GDSCPalette.purple300,
+    a2: GDSCPalette.purple500,
+    a3: GDSCPalette.purple700,
+  );
+  
+  final TintColor blue = TintColor(
+    a1: GDSCPalette.blue300.withOpacity(0.84),
+    a2: GDSCPalette.blue500,
+    a3: GDSCPalette.blue700,
+  );
+
+  final TintColor red = TintColor(
+    a1: GDSCPalette.red300,
+    a2: GDSCPalette.red500,
+    a3: GDSCPalette.red700,
+  );
+
+  final TintColor yellow = TintColor(
+    a1: GDSCPalette.yellow300,
+    a2: GDSCPalette.yellow500,
+    a3: GDSCPalette.yellow700,
+  );
+
+  final TintColor green = TintColor(
+    a1: GDSCPalette.green300,
+    a2: GDSCPalette.green500,
+    a3: GDSCPalette.green700,
+  );
+
+}
+
+class GDSCContentColors {
+
+  final white = GDSCPalette.white;
+  final black = GDSCPalette.black;
+  final gray = GrayScaleColor();
+  final tint = TintColors();
+
+}

--- a/lib/src/enum/index.dart
+++ b/lib/src/enum/index.dart
@@ -1,0 +1,1 @@
+enum GDSCColorTheme { red, yellow, green, blue }

--- a/lib/src/palette/index.dart
+++ b/lib/src/palette/index.dart
@@ -92,6 +92,17 @@ class GDSCPalette {
   static const Color cyan900 = Color(0xFF145460);
   static const Color cyan1000 = Color(0xFF0A2B31);
 
+  static const Color gray100 = Color(0xFFFFFFFF);
+  static const Color gray200 = Color(0xFFEEEEEE);
+  static const Color gray300 = Color(0xFFCCCCCC);
+  static const Color gray400 = Color(0xFFAAAAAA);
+  static const Color gray500 = Color(0xFF929292);
+  static const Color gray600 = Color(0xFF828282);
+  static const Color gray700 = Color(0xFF666666);
+  static const Color gray800 = Color(0xFF444444);
+  static const Color gray900 = Color(0xFF222222);
+  static const Color gray1000 = Color(0xFF000000);
+
   static const Color warmGray100 = Color(0xFFF0EFEF);
   static const Color warmGray200 = Color(0xFFE0DFDE);
   static const Color warmGray300 = Color(0xFFC3C0BF);

--- a/lib/src/palette/palette.style.dart
+++ b/lib/src/palette/palette.style.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
-abstract class GDSCPalette {
-
+class GDSCPalette {
   static const Color white = Colors.white; // Color(0xFFFFFFFF);
   static const Color black = Colors.black; // Color(0xFF000000);
 
@@ -47,7 +46,7 @@ abstract class GDSCPalette {
   static const Color green700 = Color(0xFF2A8642);
   static const Color green800 = Color(0xFF1F6532);
   static const Color green900 = Color(0xFF154321);
-  static const Color green1000 =  Color(0xFF0A2211);
+  static const Color green1000 = Color(0xFF0A2211);
 
   static const Color orange100 = Color(0xFFFDF2EA);
   static const Color orange200 = Color(0xFFFCE6D5);
@@ -58,7 +57,7 @@ abstract class GDSCPalette {
   static const Color orange700 = Color(0xFFC06828);
   static const Color orange800 = Color(0xFF914F1E);
   static const Color orange900 = Color(0xFF603414);
-  static const Color orange1000 =  Color(0xFF311B0A);
+  static const Color orange1000 = Color(0xFF311B0A);
 
   static const Color magenta100 = Color(0xFFFDEBF5);
   static const Color magenta200 = Color(0xFFFCD7EC);
@@ -69,7 +68,7 @@ abstract class GDSCPalette {
   static const Color magenta700 = Color(0xFFC03080);
   static const Color magenta800 = Color(0xFF912461);
   static const Color magenta900 = Color(0xFF601840);
-  static const Color magenta1000 =  Color(0xFF310C21);
+  static const Color magenta1000 = Color(0xFF310C21);
 
   static const Color purple100 = Color(0xFFF3ECFE);
   static const Color purple200 = Color(0xFFE8D8FD);
@@ -80,7 +79,7 @@ abstract class GDSCPalette {
   static const Color purple700 = Color(0xFF7035C3);
   static const Color purple800 = Color(0xFF552893);
   static const Color purple900 = Color(0xFF381A62);
-  static const Color purple1000 =  Color(0xFF1D0D32);
+  static const Color purple1000 = Color(0xFF1D0D32);
 
   static const Color cyan100 = Color(0xFFEAFAFD);
   static const Color cyan200 = Color(0xFFD5F6FC);
@@ -91,7 +90,7 @@ abstract class GDSCPalette {
   static const Color cyan700 = Color(0xFF28A8C0);
   static const Color cyan800 = Color(0xFF1E7F91);
   static const Color cyan900 = Color(0xFF145460);
-  static const Color cyan1000 =  Color(0xFF0A2B31);
+  static const Color cyan1000 = Color(0xFF0A2B31);
 
   static const Color warmGray100 = Color(0xFFF0EFEF);
   static const Color warmGray200 = Color(0xFFE0DFDE);
@@ -102,7 +101,7 @@ abstract class GDSCPalette {
   static const Color warmGray700 = Color(0xFF534E4C);
   static const Color warmGray800 = Color(0xFF3F3B39);
   static const Color warmGray900 = Color(0xFF2A2726);
-  static const Color warmGray1000 =  Color(0xFF151413);
+  static const Color warmGray1000 = Color(0xFF151413);
 
   static const Color coolGray100 = Color(0xFFEFEFF0);
   static const Color coolGray200 = Color(0xFFDEDFE0);
@@ -113,5 +112,5 @@ abstract class GDSCPalette {
   static const Color coolGray700 = Color(0xFF4C4F53);
   static const Color coolGray800 = Color(0xFF393C3F);
   static const Color coolGray900 = Color(0xFF26282A);
-  static const Color coolGray1000 =  Color(0xFF131415);
+  static const Color coolGray1000 = Color(0xFF131415);
 }

--- a/lib/src/semantic/background.dart
+++ b/lib/src/semantic/background.dart
@@ -2,58 +2,58 @@ import 'dart:ui';
 
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
-class _BackgroundTheme {
+class BackgroundColors {
   final Color solid;
   final Color gray;
 
-  const _BackgroundTheme({
+  const BackgroundColors({
     required this.solid,
     required this.gray,
   });
 }
 
-class _SemanticBackgroundTheme {
-  final _BackgroundTheme primary;
-  final _BackgroundTheme secondary;
-  final _BackgroundTheme tertiary;
+class SemanticBackgroundColors {
+  final BackgroundColors primary;
+  final BackgroundColors secondary;
+  final BackgroundColors tertiary;
 
-  const _SemanticBackgroundTheme({
+  const SemanticBackgroundColors({
     required this.primary,
     required this.secondary,
     required this.tertiary,
   });
 }
 
-class GDSCBackgroundTheme {
-  static const blue = _SemanticBackgroundTheme(
+class GDSCBackgroundColors {
+  static const blue = SemanticBackgroundColors(
       primary:
-          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white),
-      secondary: _BackgroundTheme(
+          BackgroundColors(solid: GDSCPalette.white, gray: GDSCPalette.white),
+      secondary: BackgroundColors(
           solid: GDSCPalette.blue100, gray: GDSCPalette.coolGray100),
       tertiary:
-          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white));
+          BackgroundColors(solid: GDSCPalette.white, gray: GDSCPalette.white));
 
-  static const green = _SemanticBackgroundTheme(
+  static const green = SemanticBackgroundColors(
       primary:
-          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white),
-      secondary: _BackgroundTheme(
+          BackgroundColors(solid: GDSCPalette.white, gray: GDSCPalette.white),
+      secondary: BackgroundColors(
           solid: GDSCPalette.green100, gray: GDSCPalette.coolGray100),
       tertiary:
-          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white));
+          BackgroundColors(solid: GDSCPalette.white, gray: GDSCPalette.white));
 
-  static const yellow = _SemanticBackgroundTheme(
+  static const yellow = SemanticBackgroundColors(
       primary:
-          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white),
-      secondary: _BackgroundTheme(
+          BackgroundColors(solid: GDSCPalette.white, gray: GDSCPalette.white),
+      secondary: BackgroundColors(
           solid: GDSCPalette.yellow100, gray: GDSCPalette.warmGray100),
       tertiary:
-          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white));
+          BackgroundColors(solid: GDSCPalette.white, gray: GDSCPalette.white));
 
-  static const red = _SemanticBackgroundTheme(
+  static const red = SemanticBackgroundColors(
       primary:
-          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white),
-      secondary: _BackgroundTheme(
+          BackgroundColors(solid: GDSCPalette.white, gray: GDSCPalette.white),
+      secondary: BackgroundColors(
           solid: GDSCPalette.red100, gray: GDSCPalette.warmGray100),
       tertiary:
-          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white));
+          BackgroundColors(solid: GDSCPalette.white, gray: GDSCPalette.white));
 }

--- a/lib/src/semantic/background.dart
+++ b/lib/src/semantic/background.dart
@@ -1,0 +1,59 @@
+import 'dart:ui';
+
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class _BackgroundTheme {
+  final Color solid;
+  final Color gray;
+
+  const _BackgroundTheme({
+    required this.solid,
+    required this.gray,
+  });
+}
+
+class _SemanticBackgroundTheme {
+  final _BackgroundTheme primary;
+  final _BackgroundTheme secondary;
+  final _BackgroundTheme tertiary;
+
+  const _SemanticBackgroundTheme({
+    required this.primary,
+    required this.secondary,
+    required this.tertiary,
+  });
+}
+
+class GDSCBackgroundTheme {
+  static const blue = _SemanticBackgroundTheme(
+      primary:
+          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white),
+      secondary: _BackgroundTheme(
+          solid: GDSCPalette.blue100, gray: GDSCPalette.coolGray100),
+      tertiary:
+          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white));
+
+  static const green = _SemanticBackgroundTheme(
+      primary:
+          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white),
+      secondary: _BackgroundTheme(
+          solid: GDSCPalette.green100, gray: GDSCPalette.coolGray100),
+      tertiary:
+          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white));
+
+  static const yellow = _SemanticBackgroundTheme(
+      primary:
+          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white),
+      secondary: _BackgroundTheme(
+          solid: GDSCPalette.yellow100, gray: GDSCPalette.warmGray100),
+      tertiary:
+          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white));
+
+  static const red = _SemanticBackgroundTheme(
+      primary:
+          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white),
+      secondary: _BackgroundTheme(
+          solid: GDSCPalette.red100, gray: GDSCPalette.warmGray100),
+      tertiary:
+          _BackgroundTheme(solid: GDSCPalette.white, gray: GDSCPalette.white));
+}

--- a/lib/src/semantic/border.dart
+++ b/lib/src/semantic/border.dart
@@ -1,0 +1,24 @@
+import 'dart:ui';
+
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class _SemanticBorderTheme {
+  final Color primary;
+  final Color secondary;
+
+  const _SemanticBorderTheme({
+    required this.primary,
+    required this.secondary,
+  });
+}
+
+class GDSCBorderTheme {
+  static const blue = _SemanticBorderTheme(
+      primary: GDSCPalette.coolGray400, secondary: GDSCPalette.coolGray800);
+  static const green = _SemanticBorderTheme(
+      primary: GDSCPalette.coolGray500, secondary: GDSCPalette.coolGray800);
+  static const yellow = _SemanticBorderTheme(
+      primary: GDSCPalette.warmGray400, secondary: GDSCPalette.warmGray800);
+  static const red = _SemanticBorderTheme(
+      primary: GDSCPalette.warmGray400, secondary: GDSCPalette.warmGray800);
+}

--- a/lib/src/semantic/border.dart
+++ b/lib/src/semantic/border.dart
@@ -2,23 +2,23 @@ import 'dart:ui';
 
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
-class _SemanticBorderTheme {
+class SemanticBorderColors {
   final Color primary;
   final Color secondary;
 
-  const _SemanticBorderTheme({
+  const SemanticBorderColors({
     required this.primary,
     required this.secondary,
   });
 }
 
-class GDSCBorderTheme {
-  static const blue = _SemanticBorderTheme(
+class GDSCBorderColors {
+  static const blue = SemanticBorderColors(
       primary: GDSCPalette.coolGray400, secondary: GDSCPalette.coolGray800);
-  static const green = _SemanticBorderTheme(
+  static const green = SemanticBorderColors(
       primary: GDSCPalette.coolGray500, secondary: GDSCPalette.coolGray800);
-  static const yellow = _SemanticBorderTheme(
+  static const yellow = SemanticBorderColors(
       primary: GDSCPalette.warmGray400, secondary: GDSCPalette.warmGray800);
-  static const red = _SemanticBorderTheme(
+  static const red = SemanticBorderColors(
       primary: GDSCPalette.warmGray400, secondary: GDSCPalette.warmGray800);
 }

--- a/lib/src/semantic/button.dart
+++ b/lib/src/semantic/button.dart
@@ -1,0 +1,227 @@
+import 'dart:ui';
+
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class _ButtonBackgroundTheme {
+  final Color common;
+  final Color active;
+  final Color pressed;
+  final Color loading;
+  final Color disabled;
+
+  const _ButtonBackgroundTheme({
+    required this.common,
+    required this.active,
+    required this.pressed,
+    required this.loading,
+    required this.disabled,
+  });
+}
+
+class _ButtonLabelTheme {
+  final Color common;
+  final Color active;
+  final Color pressed;
+  final Color loading;
+  final Color disabled;
+
+  const _ButtonLabelTheme({
+    required this.common,
+    required this.active,
+    required this.pressed,
+    required this.loading,
+    required this.disabled,
+  });
+}
+
+class _ButtonTheme {
+  final _ButtonBackgroundTheme background;
+  final _ButtonLabelTheme label;
+
+  const _ButtonTheme({
+    required this.background,
+    required this.label,
+  });
+}
+
+class _SemanticButtonTheme {
+  final _ButtonTheme primary;
+  final _ButtonTheme secondary;
+  final _ButtonTheme tertiary;
+
+  const _SemanticButtonTheme({
+    required this.primary,
+    required this.secondary,
+    required this.tertiary,
+  });
+}
+
+class GDSCButtonTheme {
+  static var blue = _SemanticButtonTheme(
+    primary: const _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.blue500,
+            active: GDSCPalette.blue600,
+            pressed: GDSCPalette.blue700,
+            loading: GDSCPalette.blue700,
+            disabled: GDSCPalette.coolGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.white,
+            active: GDSCPalette.white,
+            pressed: GDSCPalette.white,
+            loading: GDSCPalette.white,
+            disabled: GDSCPalette.coolGray400)),
+    secondary: _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.blue300.withOpacity(0.84),
+            active: GDSCPalette.blue400.withOpacity(0.90),
+            pressed: GDSCPalette.blue400,
+            loading: GDSCPalette.blue400,
+            disabled: GDSCPalette.coolGray200),
+        label: const _ButtonLabelTheme(
+            common: GDSCPalette.blue900,
+            active: GDSCPalette.blue900,
+            pressed: GDSCPalette.blue900,
+            loading: GDSCPalette.blue900,
+            disabled: GDSCPalette.coolGray400)),
+    tertiary: const _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.coolGray200,
+            active: GDSCPalette.coolGray300,
+            pressed: GDSCPalette.coolGray400,
+            loading: GDSCPalette.coolGray400,
+            disabled: GDSCPalette.coolGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.coolGray700,
+            active: GDSCPalette.coolGray700,
+            pressed: GDSCPalette.coolGray700,
+            loading: GDSCPalette.coolGray700,
+            disabled: GDSCPalette.coolGray400)),
+  );
+
+  static var green = _SemanticButtonTheme(
+    primary: const _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.green500,
+            active: GDSCPalette.green600,
+            pressed: GDSCPalette.green700,
+            loading: GDSCPalette.green700,
+            disabled: GDSCPalette.coolGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.white,
+            active: GDSCPalette.white,
+            pressed: GDSCPalette.white,
+            loading: GDSCPalette.white,
+            disabled: GDSCPalette.coolGray400)),
+    secondary: _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.green300.withOpacity(0.90),
+            active: GDSCPalette.green400.withOpacity(0.85),
+            pressed: GDSCPalette.green400,
+            loading: GDSCPalette.green400,
+            disabled: GDSCPalette.coolGray200),
+        label: const _ButtonLabelTheme(
+            common: GDSCPalette.green900,
+            active: GDSCPalette.green900,
+            pressed: GDSCPalette.green900,
+            loading: GDSCPalette.green900,
+            disabled: GDSCPalette.coolGray400)),
+    tertiary: const _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.coolGray200,
+            active: GDSCPalette.coolGray300,
+            pressed: GDSCPalette.coolGray400,
+            loading: GDSCPalette.coolGray400,
+            disabled: GDSCPalette.coolGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.coolGray700,
+            active: GDSCPalette.coolGray700,
+            pressed: GDSCPalette.coolGray700,
+            loading: GDSCPalette.coolGray700,
+            disabled: GDSCPalette.coolGray400)),
+  );
+
+  static var yellow = const _SemanticButtonTheme(
+    primary: _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.yellow800,
+            active: GDSCPalette.yellow900,
+            pressed: GDSCPalette.yellow1000,
+            loading: GDSCPalette.yellow1000,
+            disabled: GDSCPalette.warmGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.white,
+            active: GDSCPalette.white,
+            pressed: GDSCPalette.white,
+            loading: GDSCPalette.white,
+            disabled: GDSCPalette.warmGray400)),
+    secondary: _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.yellow300,
+            active: GDSCPalette.yellow400,
+            pressed: GDSCPalette.yellow500,
+            loading: GDSCPalette.yellow500,
+            disabled: GDSCPalette.warmGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.yellow1000,
+            active: GDSCPalette.yellow1000,
+            pressed: GDSCPalette.yellow1000,
+            loading: GDSCPalette.yellow1000,
+            disabled: GDSCPalette.warmGray400)),
+    tertiary: _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.warmGray200,
+            active: GDSCPalette.warmGray300,
+            pressed: GDSCPalette.warmGray400,
+            loading: GDSCPalette.warmGray400,
+            disabled: GDSCPalette.warmGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.warmGray700,
+            active: GDSCPalette.warmGray700,
+            pressed: GDSCPalette.warmGray700,
+            loading: GDSCPalette.warmGray700,
+            disabled: GDSCPalette.warmGray400)),
+  );
+
+  static var red = const _SemanticButtonTheme(
+    primary: _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.red600,
+            active: GDSCPalette.red700,
+            pressed: GDSCPalette.red800,
+            loading: GDSCPalette.red800,
+            disabled: GDSCPalette.warmGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.white,
+            active: GDSCPalette.white,
+            pressed: GDSCPalette.white,
+            loading: GDSCPalette.white,
+            disabled: GDSCPalette.warmGray400)),
+    secondary: _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.red300,
+            active: GDSCPalette.red400,
+            pressed: GDSCPalette.red500,
+            loading: GDSCPalette.red500,
+            disabled: GDSCPalette.warmGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.red900,
+            active: GDSCPalette.red1000,
+            pressed: GDSCPalette.red1000,
+            loading: GDSCPalette.red1000,
+            disabled: GDSCPalette.warmGray400)),
+    tertiary: _ButtonTheme(
+        background: _ButtonBackgroundTheme(
+            common: GDSCPalette.warmGray200,
+            active: GDSCPalette.warmGray300,
+            pressed: GDSCPalette.warmGray400,
+            loading: GDSCPalette.warmGray400,
+            disabled: GDSCPalette.warmGray200),
+        label: _ButtonLabelTheme(
+            common: GDSCPalette.warmGray700,
+            active: GDSCPalette.warmGray800,
+            pressed: GDSCPalette.warmGray800,
+            loading: GDSCPalette.warmGray800,
+            disabled: GDSCPalette.warmGray400)),
+  );
+}

--- a/lib/src/semantic/button.dart
+++ b/lib/src/semantic/button.dart
@@ -2,14 +2,14 @@ import 'dart:ui';
 
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
-class _ButtonBackgroundTheme {
+class ButtonBackgroundColors {
   final Color common;
   final Color active;
   final Color pressed;
   final Color loading;
   final Color disabled;
 
-  const _ButtonBackgroundTheme({
+  const ButtonBackgroundColors({
     required this.common,
     required this.active,
     required this.pressed,
@@ -18,14 +18,14 @@ class _ButtonBackgroundTheme {
   });
 }
 
-class _ButtonLabelTheme {
+class ButtonLabelColors {
   final Color common;
   final Color active;
   final Color pressed;
   final Color loading;
   final Color disabled;
 
-  const _ButtonLabelTheme({
+  const ButtonLabelColors({
     required this.common,
     required this.active,
     required this.pressed,
@@ -34,64 +34,64 @@ class _ButtonLabelTheme {
   });
 }
 
-class _ButtonTheme {
-  final _ButtonBackgroundTheme background;
-  final _ButtonLabelTheme label;
+class ButtonColors {
+  final ButtonBackgroundColors background;
+  final ButtonLabelColors label;
 
-  const _ButtonTheme({
+  const ButtonColors({
     required this.background,
     required this.label,
   });
 }
 
-class _SemanticButtonTheme {
-  final _ButtonTheme primary;
-  final _ButtonTheme secondary;
-  final _ButtonTheme tertiary;
+class SemanticButtonColors {
+  final ButtonColors primary;
+  final ButtonColors secondary;
+  final ButtonColors tertiary;
 
-  const _SemanticButtonTheme({
+  const SemanticButtonColors({
     required this.primary,
     required this.secondary,
     required this.tertiary,
   });
 }
 
-class GDSCButtonTheme {
-  static var blue = _SemanticButtonTheme(
-    primary: const _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+class GDSCButtonColors {
+  static var blue = SemanticButtonColors(
+    primary: const ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.blue500,
             active: GDSCPalette.blue600,
             pressed: GDSCPalette.blue700,
             loading: GDSCPalette.blue700,
             disabled: GDSCPalette.coolGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.white,
             active: GDSCPalette.white,
             pressed: GDSCPalette.white,
             loading: GDSCPalette.white,
             disabled: GDSCPalette.coolGray400)),
-    secondary: _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+    secondary: ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.blue300.withOpacity(0.84),
             active: GDSCPalette.blue400.withOpacity(0.90),
             pressed: GDSCPalette.blue400,
             loading: GDSCPalette.blue400,
             disabled: GDSCPalette.coolGray200),
-        label: const _ButtonLabelTheme(
+        label: const ButtonLabelColors(
             common: GDSCPalette.blue900,
             active: GDSCPalette.blue900,
             pressed: GDSCPalette.blue900,
             loading: GDSCPalette.blue900,
             disabled: GDSCPalette.coolGray400)),
-    tertiary: const _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+    tertiary: const ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.coolGray200,
             active: GDSCPalette.coolGray300,
             pressed: GDSCPalette.coolGray400,
             loading: GDSCPalette.coolGray400,
             disabled: GDSCPalette.coolGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.coolGray700,
             active: GDSCPalette.coolGray700,
             pressed: GDSCPalette.coolGray700,
@@ -99,41 +99,41 @@ class GDSCButtonTheme {
             disabled: GDSCPalette.coolGray400)),
   );
 
-  static var green = _SemanticButtonTheme(
-    primary: const _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+  static var green = SemanticButtonColors(
+    primary: const ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.green500,
             active: GDSCPalette.green600,
             pressed: GDSCPalette.green700,
             loading: GDSCPalette.green700,
             disabled: GDSCPalette.coolGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.white,
             active: GDSCPalette.white,
             pressed: GDSCPalette.white,
             loading: GDSCPalette.white,
             disabled: GDSCPalette.coolGray400)),
-    secondary: _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+    secondary: ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.green300.withOpacity(0.90),
             active: GDSCPalette.green400.withOpacity(0.85),
             pressed: GDSCPalette.green400,
             loading: GDSCPalette.green400,
             disabled: GDSCPalette.coolGray200),
-        label: const _ButtonLabelTheme(
+        label: const ButtonLabelColors(
             common: GDSCPalette.green900,
             active: GDSCPalette.green900,
             pressed: GDSCPalette.green900,
             loading: GDSCPalette.green900,
             disabled: GDSCPalette.coolGray400)),
-    tertiary: const _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+    tertiary: const ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.coolGray200,
             active: GDSCPalette.coolGray300,
             pressed: GDSCPalette.coolGray400,
             loading: GDSCPalette.coolGray400,
             disabled: GDSCPalette.coolGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.coolGray700,
             active: GDSCPalette.coolGray700,
             pressed: GDSCPalette.coolGray700,
@@ -141,41 +141,41 @@ class GDSCButtonTheme {
             disabled: GDSCPalette.coolGray400)),
   );
 
-  static var yellow = const _SemanticButtonTheme(
-    primary: _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+  static var yellow = const SemanticButtonColors(
+    primary: ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.yellow800,
             active: GDSCPalette.yellow900,
             pressed: GDSCPalette.yellow1000,
             loading: GDSCPalette.yellow1000,
             disabled: GDSCPalette.warmGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.white,
             active: GDSCPalette.white,
             pressed: GDSCPalette.white,
             loading: GDSCPalette.white,
             disabled: GDSCPalette.warmGray400)),
-    secondary: _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+    secondary: ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.yellow300,
             active: GDSCPalette.yellow400,
             pressed: GDSCPalette.yellow500,
             loading: GDSCPalette.yellow500,
             disabled: GDSCPalette.warmGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.yellow1000,
             active: GDSCPalette.yellow1000,
             pressed: GDSCPalette.yellow1000,
             loading: GDSCPalette.yellow1000,
             disabled: GDSCPalette.warmGray400)),
-    tertiary: _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+    tertiary: ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.warmGray200,
             active: GDSCPalette.warmGray300,
             pressed: GDSCPalette.warmGray400,
             loading: GDSCPalette.warmGray400,
             disabled: GDSCPalette.warmGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.warmGray700,
             active: GDSCPalette.warmGray700,
             pressed: GDSCPalette.warmGray700,
@@ -183,41 +183,41 @@ class GDSCButtonTheme {
             disabled: GDSCPalette.warmGray400)),
   );
 
-  static var red = const _SemanticButtonTheme(
-    primary: _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+  static var red = const SemanticButtonColors(
+    primary: ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.red600,
             active: GDSCPalette.red700,
             pressed: GDSCPalette.red800,
             loading: GDSCPalette.red800,
             disabled: GDSCPalette.warmGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.white,
             active: GDSCPalette.white,
             pressed: GDSCPalette.white,
             loading: GDSCPalette.white,
             disabled: GDSCPalette.warmGray400)),
-    secondary: _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+    secondary: ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.red300,
             active: GDSCPalette.red400,
             pressed: GDSCPalette.red500,
             loading: GDSCPalette.red500,
             disabled: GDSCPalette.warmGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.red900,
             active: GDSCPalette.red1000,
             pressed: GDSCPalette.red1000,
             loading: GDSCPalette.red1000,
             disabled: GDSCPalette.warmGray400)),
-    tertiary: _ButtonTheme(
-        background: _ButtonBackgroundTheme(
+    tertiary: ButtonColors(
+        background: ButtonBackgroundColors(
             common: GDSCPalette.warmGray200,
             active: GDSCPalette.warmGray300,
             pressed: GDSCPalette.warmGray400,
             loading: GDSCPalette.warmGray400,
             disabled: GDSCPalette.warmGray200),
-        label: _ButtonLabelTheme(
+        label: ButtonLabelColors(
             common: GDSCPalette.warmGray700,
             active: GDSCPalette.warmGray800,
             pressed: GDSCPalette.warmGray800,

--- a/lib/src/semantic/index.dart
+++ b/lib/src/semantic/index.dart
@@ -8,99 +8,77 @@ import 'tab_bar.dart';
 import 'tag.dart';
 import 'text_button.dart';
 
-class GDSCSemanticColor {
+class SemanticColors {
+  final SemanticBackgroundColors background;
+  final SemanticBorderColors border;
+  final SemanticButtonColors button;
+  final SemanticLineColors line;
+  final SemanticTabBarColors tabBar;
+  final SemanticTagColors tag;
+  final SemanticTextButtonColors textButton;
+
+  const SemanticColors({
+    required this.background,
+    required this.border,
+    required this.button,
+    required this.line,
+    required this.tabBar,
+    required this.tag,
+    required this.textButton,
+  });
+}
+
+class GDSCSemanticColors {
   final GDSCColorTheme currentTheme;
 
-  const GDSCSemanticColor({required this.currentTheme});
+  const GDSCSemanticColors({required this.currentTheme});
 
-  get background {
+  SemanticColors getColor() {
     switch (currentTheme) {
       case GDSCColorTheme.blue:
-        return GDSCBackgroundTheme.blue;
+        return blue;
       case GDSCColorTheme.green:
-        return GDSCBackgroundTheme.green;
+        return green;
       case GDSCColorTheme.yellow:
-        return GDSCBackgroundTheme.yellow;
+        return yellow;
       case GDSCColorTheme.red:
-        return GDSCBackgroundTheme.red;
+        return red;
     }
   }
 
-  get border {
-    switch (currentTheme) {
-      case GDSCColorTheme.blue:
-        return GDSCBorderTheme.blue;
-      case GDSCColorTheme.green:
-        return GDSCBorderTheme.green;
-      case GDSCColorTheme.yellow:
-        return GDSCBorderTheme.yellow;
-      case GDSCColorTheme.red:
-        return GDSCBorderTheme.red;
-    }
-  }
+  static final SemanticColors blue = SemanticColors(
+      background: GDSCBackgroundColors.blue,
+      border: GDSCBorderColors.blue,
+      button: GDSCButtonColors.blue,
+      line: GDSCLineColors.blue,
+      tabBar: GDSCTabBarColors.blue,
+      tag: GDSCTagColors.blue,
+      textButton: GDSCTextButtonColors.blue);
 
-  get button {
-    switch (currentTheme) {
-      case GDSCColorTheme.blue:
-        return GDSCButtonTheme.blue;
-      case GDSCColorTheme.green:
-        return GDSCButtonTheme.green;
-      case GDSCColorTheme.yellow:
-        return GDSCButtonTheme.yellow;
-      case GDSCColorTheme.red:
-        return GDSCButtonTheme.red;
-    }
-  }
+  static final SemanticColors green = SemanticColors(
+      background: GDSCBackgroundColors.green,
+      border: GDSCBorderColors.green,
+      button: GDSCButtonColors.green,
+      line: GDSCLineColors.green,
+      tabBar: GDSCTabBarColors.green,
+      tag: GDSCTagColors.green,
+      textButton: GDSCTextButtonColors.green);
 
-  get line {
-    switch (currentTheme) {
-      case GDSCColorTheme.blue:
-        return GDSCLineTheme.blue;
-      case GDSCColorTheme.green:
-        return GDSCLineTheme.green;
-      case GDSCColorTheme.yellow:
-        return GDSCLineTheme.yellow;
-      case GDSCColorTheme.red:
-        return GDSCLineTheme.red;
-    }
-  }
+  static final SemanticColors yellow = SemanticColors(
+      background: GDSCBackgroundColors.yellow,
+      border: GDSCBorderColors.yellow,
+      button: GDSCButtonColors.yellow,
+      line: GDSCLineColors.yellow,
+      tabBar: GDSCTabBarColors.yellow,
+      tag: GDSCTagColors.yellow,
+      textButton: GDSCTextButtonColors.yellow);
 
-  get tabBar {
-    switch (currentTheme) {
-      case GDSCColorTheme.blue:
-        return GDSCTabBarTheme.blue;
-      case GDSCColorTheme.green:
-        return GDSCTabBarTheme.green;
-      case GDSCColorTheme.yellow:
-        return GDSCTabBarTheme.yellow;
-      case GDSCColorTheme.red:
-        return GDSCTabBarTheme.red;
-    }
-  }
-
-  get tag {
-    switch (currentTheme) {
-      case GDSCColorTheme.blue:
-        return GDSCTagTheme.blue;
-      case GDSCColorTheme.green:
-        return GDSCTagTheme.green;
-      case GDSCColorTheme.yellow:
-        return GDSCTagTheme.yellow;
-      case GDSCColorTheme.red:
-        return GDSCTagTheme.red;
-    }
-  }
-
-  get textButton {
-    switch (currentTheme) {
-      case GDSCColorTheme.blue:
-        return GDSCTextButtonTheme.blue;
-      case GDSCColorTheme.green:
-        return GDSCTextButtonTheme.green;
-      case GDSCColorTheme.yellow:
-        return GDSCTextButtonTheme.yellow;
-      case GDSCColorTheme.red:
-        return GDSCTextButtonTheme.red;
-    }
-  }
+  static final SemanticColors red = SemanticColors(
+      background: GDSCBackgroundColors.red,
+      border: GDSCBorderColors.red,
+      button: GDSCButtonColors.red,
+      line: GDSCLineColors.red,
+      tabBar: GDSCTabBarColors.red,
+      tag: GDSCTagColors.red,
+      textButton: GDSCTextButtonColors.red);
 }

--- a/lib/src/semantic/index.dart
+++ b/lib/src/semantic/index.dart
@@ -1,0 +1,106 @@
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+import 'background.dart';
+import 'border.dart';
+import 'button.dart';
+import 'line.dart';
+import 'tab_bar.dart';
+import 'tag.dart';
+import 'text_button.dart';
+
+class GDSCSemanticColor {
+  final GDSCColorTheme currentTheme;
+
+  const GDSCSemanticColor({required this.currentTheme});
+
+  get background {
+    switch (currentTheme) {
+      case GDSCColorTheme.blue:
+        return GDSCBackgroundTheme.blue;
+      case GDSCColorTheme.green:
+        return GDSCBackgroundTheme.green;
+      case GDSCColorTheme.yellow:
+        return GDSCBackgroundTheme.yellow;
+      case GDSCColorTheme.red:
+        return GDSCBackgroundTheme.red;
+    }
+  }
+
+  get border {
+    switch (currentTheme) {
+      case GDSCColorTheme.blue:
+        return GDSCBorderTheme.blue;
+      case GDSCColorTheme.green:
+        return GDSCBorderTheme.green;
+      case GDSCColorTheme.yellow:
+        return GDSCBorderTheme.yellow;
+      case GDSCColorTheme.red:
+        return GDSCBorderTheme.red;
+    }
+  }
+
+  get button {
+    switch (currentTheme) {
+      case GDSCColorTheme.blue:
+        return GDSCButtonTheme.blue;
+      case GDSCColorTheme.green:
+        return GDSCButtonTheme.green;
+      case GDSCColorTheme.yellow:
+        return GDSCButtonTheme.yellow;
+      case GDSCColorTheme.red:
+        return GDSCButtonTheme.red;
+    }
+  }
+
+  get line {
+    switch (currentTheme) {
+      case GDSCColorTheme.blue:
+        return GDSCLineTheme.blue;
+      case GDSCColorTheme.green:
+        return GDSCLineTheme.green;
+      case GDSCColorTheme.yellow:
+        return GDSCLineTheme.yellow;
+      case GDSCColorTheme.red:
+        return GDSCLineTheme.red;
+    }
+  }
+
+  get tabBar {
+    switch (currentTheme) {
+      case GDSCColorTheme.blue:
+        return GDSCTabBarTheme.blue;
+      case GDSCColorTheme.green:
+        return GDSCTabBarTheme.green;
+      case GDSCColorTheme.yellow:
+        return GDSCTabBarTheme.yellow;
+      case GDSCColorTheme.red:
+        return GDSCTabBarTheme.red;
+    }
+  }
+
+  get tag {
+    switch (currentTheme) {
+      case GDSCColorTheme.blue:
+        return GDSCTagTheme.blue;
+      case GDSCColorTheme.green:
+        return GDSCTagTheme.green;
+      case GDSCColorTheme.yellow:
+        return GDSCTagTheme.yellow;
+      case GDSCColorTheme.red:
+        return GDSCTagTheme.red;
+    }
+  }
+
+  get textButton {
+    switch (currentTheme) {
+      case GDSCColorTheme.blue:
+        return GDSCTextButtonTheme.blue;
+      case GDSCColorTheme.green:
+        return GDSCTextButtonTheme.green;
+      case GDSCColorTheme.yellow:
+        return GDSCTextButtonTheme.yellow;
+      case GDSCColorTheme.red:
+        return GDSCTextButtonTheme.red;
+    }
+  }
+}

--- a/lib/src/semantic/index.dart
+++ b/lib/src/semantic/index.dart
@@ -1,5 +1,6 @@
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
+import '../content/index.dart';
 import 'background.dart';
 import 'border.dart';
 import 'button.dart';
@@ -16,8 +17,9 @@ class SemanticColors {
   final SemanticTabBarColors tabBar;
   final SemanticTagColors tag;
   final SemanticTextButtonColors textButton;
+  final GDSCContentColors content = GDSCContentColors();
 
-  const SemanticColors({
+  SemanticColors({
     required this.background,
     required this.border,
     required this.button,
@@ -71,7 +73,7 @@ class GDSCSemanticColors {
       textButton: GDSCTextButtonColors.red);
 
   GDSCSemanticColors({required this.currentTheme}) {
-    switch(currentTheme) {
+    switch (currentTheme) {
       case GDSCColorTheme.blue:
         currentColors = blue;
         break;

--- a/lib/src/semantic/index.dart
+++ b/lib/src/semantic/index.dart
@@ -30,21 +30,9 @@ class SemanticColors {
 
 class GDSCSemanticColors {
   final GDSCColorTheme currentTheme;
+  late SemanticColors currentColors;
 
-  const GDSCSemanticColors({required this.currentTheme});
-
-  SemanticColors getColor() {
-    switch (currentTheme) {
-      case GDSCColorTheme.blue:
-        return blue;
-      case GDSCColorTheme.green:
-        return green;
-      case GDSCColorTheme.yellow:
-        return yellow;
-      case GDSCColorTheme.red:
-        return red;
-    }
-  }
+  get colors => currentColors;
 
   static final SemanticColors blue = SemanticColors(
       background: GDSCBackgroundColors.blue,
@@ -81,4 +69,21 @@ class GDSCSemanticColors {
       tabBar: GDSCTabBarColors.red,
       tag: GDSCTagColors.red,
       textButton: GDSCTextButtonColors.red);
+
+  GDSCSemanticColors({required this.currentTheme}) {
+    switch(currentTheme) {
+      case GDSCColorTheme.blue:
+        currentColors = blue;
+        break;
+      case GDSCColorTheme.green:
+        currentColors = green;
+        break;
+      case GDSCColorTheme.yellow:
+        currentColors = yellow;
+        break;
+      case GDSCColorTheme.red:
+        currentColors = red;
+        break;
+    }
+  }
 }

--- a/lib/src/semantic/line.dart
+++ b/lib/src/semantic/line.dart
@@ -2,23 +2,23 @@ import 'dart:ui';
 
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
-class _SemanticLineTheme {
+class SemanticLineColors {
   final Color primary;
   final Color secondary;
 
-  const _SemanticLineTheme({
+  const SemanticLineColors({
     required this.primary,
     required this.secondary,
   });
 }
 
-class GDSCLineTheme {
-  static const blue = _SemanticLineTheme(
+class GDSCLineColors {
+  static const blue = SemanticLineColors(
       primary: GDSCPalette.coolGray400, secondary: GDSCPalette.coolGray800);
-  static const green = _SemanticLineTheme(
+  static const green = SemanticLineColors(
       primary: GDSCPalette.coolGray500, secondary: GDSCPalette.coolGray800);
-  static const yellow = _SemanticLineTheme(
+  static const yellow = SemanticLineColors(
       primary: GDSCPalette.warmGray400, secondary: GDSCPalette.warmGray800);
-  static const red = _SemanticLineTheme(
+  static const red = SemanticLineColors(
       primary: GDSCPalette.warmGray400, secondary: GDSCPalette.warmGray800);
 }

--- a/lib/src/semantic/line.dart
+++ b/lib/src/semantic/line.dart
@@ -1,0 +1,24 @@
+import 'dart:ui';
+
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class _SemanticLineTheme {
+  final Color primary;
+  final Color secondary;
+
+  const _SemanticLineTheme({
+    required this.primary,
+    required this.secondary,
+  });
+}
+
+class GDSCLineTheme {
+  static const blue = _SemanticLineTheme(
+      primary: GDSCPalette.coolGray400, secondary: GDSCPalette.coolGray800);
+  static const green = _SemanticLineTheme(
+      primary: GDSCPalette.coolGray500, secondary: GDSCPalette.coolGray800);
+  static const yellow = _SemanticLineTheme(
+      primary: GDSCPalette.warmGray400, secondary: GDSCPalette.warmGray800);
+  static const red = _SemanticLineTheme(
+      primary: GDSCPalette.warmGray400, secondary: GDSCPalette.warmGray800);
+}

--- a/lib/src/semantic/tab_bar.dart
+++ b/lib/src/semantic/tab_bar.dart
@@ -1,0 +1,181 @@
+import 'dart:ui';
+
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class _TabBarLabelTheme {
+  final Color common;
+  final Color active;
+  final Color pressed;
+  final Color loading;
+  final Color disabled;
+
+  const _TabBarLabelTheme({
+    required this.common,
+    required this.active,
+    required this.pressed,
+    required this.loading,
+    required this.disabled,
+  });
+}
+
+class _TabBarBackgroundTheme {
+  final Color active;
+  final Color pressed;
+
+  const _TabBarBackgroundTheme({
+    required this.active,
+    required this.pressed,
+  });
+}
+
+class _TabBarTheme {
+  final _TabBarLabelTheme label;
+  final _TabBarBackgroundTheme background;
+
+  const _TabBarTheme({
+    required this.label,
+    required this.background,
+  });
+}
+
+class _SemanticTabBarTheme {
+  final _TabBarTheme primary;
+  final _TabBarTheme secondary;
+  final _TabBarTheme tertiary;
+
+  const _SemanticTabBarTheme({
+    required this.primary,
+    required this.secondary,
+    required this.tertiary,
+  });
+}
+
+class GDSCTabBarTheme {
+  static var blue = _SemanticTabBarTheme(
+      primary: _TabBarTheme(
+          label: const _TabBarLabelTheme(
+              common: GDSCPalette.blue500,
+              active: GDSCPalette.blue600,
+              pressed: GDSCPalette.blue700,
+              loading: GDSCPalette.blue700,
+              disabled: GDSCPalette.coolGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.coolGray200.withOpacity(0.64),
+              pressed: GDSCPalette.coolGray200.withOpacity(0.72))),
+      secondary: _TabBarTheme(
+          label: const _TabBarLabelTheme(
+              common: GDSCPalette.blue500,
+              active: GDSCPalette.blue600,
+              pressed: GDSCPalette.blue700,
+              loading: GDSCPalette.blue700,
+              disabled: GDSCPalette.coolGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.blue300.withOpacity(0.64),
+              pressed: GDSCPalette.blue300.withOpacity(0.72))),
+      tertiary: _TabBarTheme(
+          label: const _TabBarLabelTheme(
+              common: GDSCPalette.coolGray800,
+              active: GDSCPalette.coolGray900,
+              pressed: GDSCPalette.coolGray1000,
+              loading: GDSCPalette.coolGray1000,
+              disabled: GDSCPalette.coolGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.coolGray200.withOpacity(0.64),
+              pressed: GDSCPalette.coolGray200.withOpacity(0.72))));
+
+  static var green = _SemanticTabBarTheme(
+      primary: _TabBarTheme(
+          label: const _TabBarLabelTheme(
+              common: GDSCPalette.green500,
+              active: GDSCPalette.green600,
+              pressed: GDSCPalette.green700,
+              loading: GDSCPalette.green700,
+              disabled: GDSCPalette.coolGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.coolGray200.withOpacity(0.64),
+              pressed: GDSCPalette.coolGray200.withOpacity(0.72))),
+      secondary: _TabBarTheme(
+          label: const _TabBarLabelTheme(
+              common: GDSCPalette.green500,
+              active: GDSCPalette.green600,
+              pressed: GDSCPalette.green700,
+              loading: GDSCPalette.green700,
+              disabled: GDSCPalette.coolGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.green300.withOpacity(0.64),
+              pressed: GDSCPalette.green300.withOpacity(0.72))),
+      tertiary: _TabBarTheme(
+          label: const _TabBarLabelTheme(
+              common: GDSCPalette.coolGray800,
+              active: GDSCPalette.coolGray900,
+              pressed: GDSCPalette.coolGray1000,
+              loading: GDSCPalette.coolGray1000,
+              disabled: GDSCPalette.coolGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.coolGray200.withOpacity(0.64),
+              pressed: GDSCPalette.coolGray200.withOpacity(0.72))));
+
+  static var yellow = _SemanticTabBarTheme(
+      primary: _TabBarTheme(
+          label: _TabBarLabelTheme(
+              common: GDSCPalette.yellow800,
+              active: GDSCPalette.yellow900,
+              pressed: GDSCPalette.yellow1000.withOpacity(0.84),
+              loading: GDSCPalette.yellow1000.withOpacity(0.84),
+              disabled: GDSCPalette.warmGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.warmGray200.withOpacity(0.64),
+              pressed: GDSCPalette.warmGray200.withOpacity(0.72))),
+      secondary: _TabBarTheme(
+          label: _TabBarLabelTheme(
+              common: GDSCPalette.yellow800,
+              active: GDSCPalette.yellow900,
+              pressed: GDSCPalette.yellow1000.withOpacity(0.84),
+              loading: GDSCPalette.yellow1000.withOpacity(0.84),
+              disabled: GDSCPalette.warmGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.yellow300.withOpacity(0.64),
+              pressed: GDSCPalette.yellow300.withOpacity(0.72))),
+      tertiary: _TabBarTheme(
+          label: const _TabBarLabelTheme(
+              common: GDSCPalette.warmGray800,
+              active: GDSCPalette.warmGray900,
+              pressed: GDSCPalette.warmGray1000,
+              loading: GDSCPalette.warmGray1000,
+              disabled: GDSCPalette.warmGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.warmGray200.withOpacity(0.64),
+              pressed: GDSCPalette.warmGray200.withOpacity(0.72))));
+
+  static var red = _SemanticTabBarTheme(
+      primary: _TabBarTheme(
+          label: _TabBarLabelTheme(
+              common: GDSCPalette.red600,
+              active: GDSCPalette.red700.withOpacity(0.84),
+              pressed: GDSCPalette.red700,
+              loading: GDSCPalette.red1000,
+              disabled: GDSCPalette.warmGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.warmGray200.withOpacity(0.64),
+              pressed: GDSCPalette.warmGray200.withOpacity(0.72))),
+      secondary: _TabBarTheme(
+          label: _TabBarLabelTheme(
+              common: GDSCPalette.red500,
+              active: GDSCPalette.red600,
+              pressed: GDSCPalette.red700.withOpacity(0.84),
+              loading: GDSCPalette.red700.withOpacity(0.84),
+              disabled: GDSCPalette.warmGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.red300.withOpacity(0.64),
+              pressed: GDSCPalette.red300.withOpacity(0.72))),
+      tertiary: _TabBarTheme(
+          label: const _TabBarLabelTheme(
+              common: GDSCPalette.warmGray800,
+              active: GDSCPalette.warmGray900,
+              pressed: GDSCPalette.warmGray1000,
+              loading: GDSCPalette.warmGray1000,
+              disabled: GDSCPalette.warmGray400),
+          background: _TabBarBackgroundTheme(
+              active: GDSCPalette.warmGray200.withOpacity(0.64),
+              pressed: GDSCPalette.warmGray200.withOpacity(0.72))));
+}

--- a/lib/src/semantic/tab_bar.dart
+++ b/lib/src/semantic/tab_bar.dart
@@ -2,14 +2,14 @@ import 'dart:ui';
 
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
-class _TabBarLabelTheme {
+class TabBarLabelColors {
   final Color common;
   final Color active;
   final Color pressed;
   final Color loading;
   final Color disabled;
 
-  const _TabBarLabelTheme({
+  const TabBarLabelColors({
     required this.common,
     required this.active,
     required this.pressed,
@@ -18,164 +18,164 @@ class _TabBarLabelTheme {
   });
 }
 
-class _TabBarBackgroundTheme {
+class TabBarBackgroundColors {
   final Color active;
   final Color pressed;
 
-  const _TabBarBackgroundTheme({
+  const TabBarBackgroundColors({
     required this.active,
     required this.pressed,
   });
 }
 
-class _TabBarTheme {
-  final _TabBarLabelTheme label;
-  final _TabBarBackgroundTheme background;
+class TabBarColors {
+  final TabBarLabelColors label;
+  final TabBarBackgroundColors background;
 
-  const _TabBarTheme({
+  const TabBarColors({
     required this.label,
     required this.background,
   });
 }
 
-class _SemanticTabBarTheme {
-  final _TabBarTheme primary;
-  final _TabBarTheme secondary;
-  final _TabBarTheme tertiary;
+class SemanticTabBarColors {
+  final TabBarColors primary;
+  final TabBarColors secondary;
+  final TabBarColors tertiary;
 
-  const _SemanticTabBarTheme({
+  const SemanticTabBarColors({
     required this.primary,
     required this.secondary,
     required this.tertiary,
   });
 }
 
-class GDSCTabBarTheme {
-  static var blue = _SemanticTabBarTheme(
-      primary: _TabBarTheme(
-          label: const _TabBarLabelTheme(
+class GDSCTabBarColors {
+  static var blue = SemanticTabBarColors(
+      primary: TabBarColors(
+          label: const TabBarLabelColors(
               common: GDSCPalette.blue500,
               active: GDSCPalette.blue600,
               pressed: GDSCPalette.blue700,
               loading: GDSCPalette.blue700,
               disabled: GDSCPalette.coolGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.coolGray200.withOpacity(0.64),
               pressed: GDSCPalette.coolGray200.withOpacity(0.72))),
-      secondary: _TabBarTheme(
-          label: const _TabBarLabelTheme(
+      secondary: TabBarColors(
+          label: const TabBarLabelColors(
               common: GDSCPalette.blue500,
               active: GDSCPalette.blue600,
               pressed: GDSCPalette.blue700,
               loading: GDSCPalette.blue700,
               disabled: GDSCPalette.coolGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.blue300.withOpacity(0.64),
               pressed: GDSCPalette.blue300.withOpacity(0.72))),
-      tertiary: _TabBarTheme(
-          label: const _TabBarLabelTheme(
+      tertiary: TabBarColors(
+          label: const TabBarLabelColors(
               common: GDSCPalette.coolGray800,
               active: GDSCPalette.coolGray900,
               pressed: GDSCPalette.coolGray1000,
               loading: GDSCPalette.coolGray1000,
               disabled: GDSCPalette.coolGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.coolGray200.withOpacity(0.64),
               pressed: GDSCPalette.coolGray200.withOpacity(0.72))));
 
-  static var green = _SemanticTabBarTheme(
-      primary: _TabBarTheme(
-          label: const _TabBarLabelTheme(
+  static var green = SemanticTabBarColors(
+      primary: TabBarColors(
+          label: const TabBarLabelColors(
               common: GDSCPalette.green500,
               active: GDSCPalette.green600,
               pressed: GDSCPalette.green700,
               loading: GDSCPalette.green700,
               disabled: GDSCPalette.coolGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.coolGray200.withOpacity(0.64),
               pressed: GDSCPalette.coolGray200.withOpacity(0.72))),
-      secondary: _TabBarTheme(
-          label: const _TabBarLabelTheme(
+      secondary: TabBarColors(
+          label: const TabBarLabelColors(
               common: GDSCPalette.green500,
               active: GDSCPalette.green600,
               pressed: GDSCPalette.green700,
               loading: GDSCPalette.green700,
               disabled: GDSCPalette.coolGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.green300.withOpacity(0.64),
               pressed: GDSCPalette.green300.withOpacity(0.72))),
-      tertiary: _TabBarTheme(
-          label: const _TabBarLabelTheme(
+      tertiary: TabBarColors(
+          label: const TabBarLabelColors(
               common: GDSCPalette.coolGray800,
               active: GDSCPalette.coolGray900,
               pressed: GDSCPalette.coolGray1000,
               loading: GDSCPalette.coolGray1000,
               disabled: GDSCPalette.coolGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.coolGray200.withOpacity(0.64),
               pressed: GDSCPalette.coolGray200.withOpacity(0.72))));
 
-  static var yellow = _SemanticTabBarTheme(
-      primary: _TabBarTheme(
-          label: _TabBarLabelTheme(
+  static var yellow = SemanticTabBarColors(
+      primary: TabBarColors(
+          label: TabBarLabelColors(
               common: GDSCPalette.yellow800,
               active: GDSCPalette.yellow900,
               pressed: GDSCPalette.yellow1000.withOpacity(0.84),
               loading: GDSCPalette.yellow1000.withOpacity(0.84),
               disabled: GDSCPalette.warmGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.warmGray200.withOpacity(0.64),
               pressed: GDSCPalette.warmGray200.withOpacity(0.72))),
-      secondary: _TabBarTheme(
-          label: _TabBarLabelTheme(
+      secondary: TabBarColors(
+          label: TabBarLabelColors(
               common: GDSCPalette.yellow800,
               active: GDSCPalette.yellow900,
               pressed: GDSCPalette.yellow1000.withOpacity(0.84),
               loading: GDSCPalette.yellow1000.withOpacity(0.84),
               disabled: GDSCPalette.warmGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.yellow300.withOpacity(0.64),
               pressed: GDSCPalette.yellow300.withOpacity(0.72))),
-      tertiary: _TabBarTheme(
-          label: const _TabBarLabelTheme(
+      tertiary: TabBarColors(
+          label: const TabBarLabelColors(
               common: GDSCPalette.warmGray800,
               active: GDSCPalette.warmGray900,
               pressed: GDSCPalette.warmGray1000,
               loading: GDSCPalette.warmGray1000,
               disabled: GDSCPalette.warmGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.warmGray200.withOpacity(0.64),
               pressed: GDSCPalette.warmGray200.withOpacity(0.72))));
 
-  static var red = _SemanticTabBarTheme(
-      primary: _TabBarTheme(
-          label: _TabBarLabelTheme(
+  static var red = SemanticTabBarColors(
+      primary: TabBarColors(
+          label: TabBarLabelColors(
               common: GDSCPalette.red600,
               active: GDSCPalette.red700.withOpacity(0.84),
               pressed: GDSCPalette.red700,
               loading: GDSCPalette.red1000,
               disabled: GDSCPalette.warmGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.warmGray200.withOpacity(0.64),
               pressed: GDSCPalette.warmGray200.withOpacity(0.72))),
-      secondary: _TabBarTheme(
-          label: _TabBarLabelTheme(
+      secondary: TabBarColors(
+          label: TabBarLabelColors(
               common: GDSCPalette.red500,
               active: GDSCPalette.red600,
               pressed: GDSCPalette.red700.withOpacity(0.84),
               loading: GDSCPalette.red700.withOpacity(0.84),
               disabled: GDSCPalette.warmGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.red300.withOpacity(0.64),
               pressed: GDSCPalette.red300.withOpacity(0.72))),
-      tertiary: _TabBarTheme(
-          label: const _TabBarLabelTheme(
+      tertiary: TabBarColors(
+          label: const TabBarLabelColors(
               common: GDSCPalette.warmGray800,
               active: GDSCPalette.warmGray900,
               pressed: GDSCPalette.warmGray1000,
               loading: GDSCPalette.warmGray1000,
               disabled: GDSCPalette.warmGray400),
-          background: _TabBarBackgroundTheme(
+          background: TabBarBackgroundColors(
               active: GDSCPalette.warmGray200.withOpacity(0.64),
               pressed: GDSCPalette.warmGray200.withOpacity(0.72))));
 }

--- a/lib/src/semantic/tag.dart
+++ b/lib/src/semantic/tag.dart
@@ -1,0 +1,124 @@
+import 'dart:ui';
+
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class _TagBackgroundTheme {
+  final Color common;
+  final Color disabled;
+
+  const _TagBackgroundTheme({
+    required this.common,
+    required this.disabled,
+  });
+}
+
+class _TagLabelTheme {
+  final Color common;
+  final Color disabled;
+
+  const _TagLabelTheme({
+    required this.common,
+    required this.disabled,
+  });
+}
+
+class _TagTheme {
+  final _TagBackgroundTheme background;
+  final _TagLabelTheme label;
+
+  const _TagTheme({
+    required this.background,
+    required this.label,
+  });
+}
+
+class _SemanticTagTheme {
+  final _TagTheme primary;
+  final _TagTheme secondary;
+  final _TagTheme tertiary;
+
+  const _SemanticTagTheme({
+    required this.primary,
+    required this.secondary,
+    required this.tertiary,
+  });
+}
+
+class GDSCTagTheme {
+  static const blue = _SemanticTagTheme(
+      primary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.blue500, disabled: GDSCPalette.coolGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.white, disabled: GDSCPalette.coolGray400)),
+      secondary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.blue300, disabled: GDSCPalette.coolGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.blue900, disabled: GDSCPalette.coolGray400)),
+      tertiary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.coolGray200,
+              disabled: GDSCPalette.coolGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.coolGray700,
+              disabled: GDSCPalette.coolGray400)));
+
+  static const green = _SemanticTagTheme(
+      primary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.green500, disabled: GDSCPalette.coolGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.white, disabled: GDSCPalette.coolGray400)),
+      secondary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.green300, disabled: GDSCPalette.coolGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.green900, disabled: GDSCPalette.coolGray400)),
+      tertiary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.coolGray200,
+              disabled: GDSCPalette.coolGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.coolGray700,
+              disabled: GDSCPalette.coolGray400)));
+
+  static const yellow = _SemanticTagTheme(
+      primary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.yellow800, disabled: GDSCPalette.warmGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.white, disabled: GDSCPalette.warmGray400)),
+      secondary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.yellow300, disabled: GDSCPalette.warmGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.yellow1000,
+              disabled: GDSCPalette.warmGray400)),
+      tertiary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.warmGray200,
+              disabled: GDSCPalette.warmGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.warmGray700,
+              disabled: GDSCPalette.warmGray400)));
+
+  static const red = _SemanticTagTheme(
+      primary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.red600, disabled: GDSCPalette.warmGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.white, disabled: GDSCPalette.warmGray400)),
+      secondary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.red300, disabled: GDSCPalette.warmGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.red900, disabled: GDSCPalette.warmGray400)),
+      tertiary: _TagTheme(
+          background: _TagBackgroundTheme(
+              common: GDSCPalette.warmGray200,
+              disabled: GDSCPalette.warmGray200),
+          label: _TagLabelTheme(
+              common: GDSCPalette.warmGray700,
+              disabled: GDSCPalette.warmGray400)));
+}

--- a/lib/src/semantic/tag.dart
+++ b/lib/src/semantic/tag.dart
@@ -2,123 +2,123 @@ import 'dart:ui';
 
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
-class _TagBackgroundTheme {
+class TagBackgroundColors {
   final Color common;
   final Color disabled;
 
-  const _TagBackgroundTheme({
+  const TagBackgroundColors({
     required this.common,
     required this.disabled,
   });
 }
 
-class _TagLabelTheme {
+class TagLabelColors {
   final Color common;
   final Color disabled;
 
-  const _TagLabelTheme({
+  const TagLabelColors({
     required this.common,
     required this.disabled,
   });
 }
 
-class _TagTheme {
-  final _TagBackgroundTheme background;
-  final _TagLabelTheme label;
+class TagColors {
+  final TagBackgroundColors background;
+  final TagLabelColors label;
 
-  const _TagTheme({
+  const TagColors({
     required this.background,
     required this.label,
   });
 }
 
-class _SemanticTagTheme {
-  final _TagTheme primary;
-  final _TagTheme secondary;
-  final _TagTheme tertiary;
+class SemanticTagColors {
+  final TagColors primary;
+  final TagColors secondary;
+  final TagColors tertiary;
 
-  const _SemanticTagTheme({
+  const SemanticTagColors({
     required this.primary,
     required this.secondary,
     required this.tertiary,
   });
 }
 
-class GDSCTagTheme {
-  static const blue = _SemanticTagTheme(
-      primary: _TagTheme(
-          background: _TagBackgroundTheme(
+class GDSCTagColors {
+  static const blue = SemanticTagColors(
+      primary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.blue500, disabled: GDSCPalette.coolGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.white, disabled: GDSCPalette.coolGray400)),
-      secondary: _TagTheme(
-          background: _TagBackgroundTheme(
+      secondary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.blue300, disabled: GDSCPalette.coolGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.blue900, disabled: GDSCPalette.coolGray400)),
-      tertiary: _TagTheme(
-          background: _TagBackgroundTheme(
+      tertiary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.coolGray200,
               disabled: GDSCPalette.coolGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.coolGray700,
               disabled: GDSCPalette.coolGray400)));
 
-  static const green = _SemanticTagTheme(
-      primary: _TagTheme(
-          background: _TagBackgroundTheme(
+  static const green = SemanticTagColors(
+      primary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.green500, disabled: GDSCPalette.coolGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.white, disabled: GDSCPalette.coolGray400)),
-      secondary: _TagTheme(
-          background: _TagBackgroundTheme(
+      secondary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.green300, disabled: GDSCPalette.coolGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.green900, disabled: GDSCPalette.coolGray400)),
-      tertiary: _TagTheme(
-          background: _TagBackgroundTheme(
+      tertiary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.coolGray200,
               disabled: GDSCPalette.coolGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.coolGray700,
               disabled: GDSCPalette.coolGray400)));
 
-  static const yellow = _SemanticTagTheme(
-      primary: _TagTheme(
-          background: _TagBackgroundTheme(
+  static const yellow = SemanticTagColors(
+      primary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.yellow800, disabled: GDSCPalette.warmGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.white, disabled: GDSCPalette.warmGray400)),
-      secondary: _TagTheme(
-          background: _TagBackgroundTheme(
+      secondary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.yellow300, disabled: GDSCPalette.warmGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.yellow1000,
               disabled: GDSCPalette.warmGray400)),
-      tertiary: _TagTheme(
-          background: _TagBackgroundTheme(
+      tertiary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.warmGray200,
               disabled: GDSCPalette.warmGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.warmGray700,
               disabled: GDSCPalette.warmGray400)));
 
-  static const red = _SemanticTagTheme(
-      primary: _TagTheme(
-          background: _TagBackgroundTheme(
+  static const red = SemanticTagColors(
+      primary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.red600, disabled: GDSCPalette.warmGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.white, disabled: GDSCPalette.warmGray400)),
-      secondary: _TagTheme(
-          background: _TagBackgroundTheme(
+      secondary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.red300, disabled: GDSCPalette.warmGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.red900, disabled: GDSCPalette.warmGray400)),
-      tertiary: _TagTheme(
-          background: _TagBackgroundTheme(
+      tertiary: TagColors(
+          background: TagBackgroundColors(
               common: GDSCPalette.warmGray200,
               disabled: GDSCPalette.warmGray200),
-          label: _TagLabelTheme(
+          label: TagLabelColors(
               common: GDSCPalette.warmGray700,
               disabled: GDSCPalette.warmGray400)));
 }

--- a/lib/src/semantic/text_button.dart
+++ b/lib/src/semantic/text_button.dart
@@ -1,0 +1,196 @@
+import 'dart:ui';
+
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class _TextButtonBackgroundTheme {
+  final Color active;
+  final Color pressed;
+
+  const _TextButtonBackgroundTheme({
+    required this.active,
+    required this.pressed,
+  });
+}
+
+class _TextButtonLabelTheme {
+  final Color common;
+  final Color active;
+  final Color pressed;
+  final Color loading;
+  final Color disabled;
+
+  const _TextButtonLabelTheme({
+    required this.common,
+    required this.active,
+    required this.pressed,
+    required this.loading,
+    required this.disabled,
+  });
+}
+
+class _TextButtonTheme {
+  final _TextButtonBackgroundTheme background;
+  final _TextButtonLabelTheme label;
+
+  const _TextButtonTheme({
+    required this.background,
+    required this.label,
+  });
+}
+
+class _SemanticTextButtonTheme {
+  final _TextButtonTheme primary;
+  final _TextButtonTheme secondary;
+  final _TextButtonTheme tertiary;
+
+  const _SemanticTextButtonTheme({
+    required this.primary,
+    required this.secondary,
+    required this.tertiary,
+  });
+}
+
+class GDSCTextButtonTheme {
+  static var blue = _SemanticTextButtonTheme(
+    primary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+            active: GDSCPalette.coolGray200.withOpacity(0.64),
+            pressed: GDSCPalette.coolGray200.withOpacity(0.72)),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.blue500,
+            active: GDSCPalette.blue600,
+            pressed: GDSCPalette.blue700,
+            loading: GDSCPalette.blue700,
+            disabled: GDSCPalette.coolGray400)),
+    secondary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.blue300.withOpacity(0.64),
+          pressed: GDSCPalette.blue300.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.blue500,
+            active: GDSCPalette.blue600,
+            pressed: GDSCPalette.blue700,
+            loading: GDSCPalette.blue700,
+            disabled: GDSCPalette.coolGray400)),
+    tertiary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.coolGray200.withOpacity(0.64),
+          pressed: GDSCPalette.coolGray200.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.coolGray800,
+            active: GDSCPalette.coolGray900,
+            pressed: GDSCPalette.coolGray1000,
+            loading: GDSCPalette.coolGray1000,
+            disabled: GDSCPalette.coolGray400)),
+  );
+
+  static var green = _SemanticTextButtonTheme(
+    primary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.coolGray200.withOpacity(0.64),
+          pressed: GDSCPalette.coolGray200.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.green500,
+            active: GDSCPalette.green600,
+            pressed: GDSCPalette.green700,
+            loading: GDSCPalette.green700,
+            disabled: GDSCPalette.coolGray400)),
+    secondary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.green300.withOpacity(0.64),
+          pressed: GDSCPalette.green300.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.green500,
+            active: GDSCPalette.green600,
+            pressed: GDSCPalette.green700,
+            loading: GDSCPalette.green700,
+            disabled: GDSCPalette.coolGray400)),
+    tertiary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.coolGray200.withOpacity(0.64),
+          pressed: GDSCPalette.coolGray200.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.coolGray800,
+            active: GDSCPalette.coolGray900,
+            pressed: GDSCPalette.coolGray1000,
+            loading: GDSCPalette.coolGray1000,
+            disabled: GDSCPalette.coolGray400)),
+  );
+
+  static var yellow = _SemanticTextButtonTheme(
+    primary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.warmGray200.withOpacity(0.64),
+          pressed: GDSCPalette.warmGray200.withOpacity(0.64),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.yellow800,
+            active: GDSCPalette.yellow900,
+            pressed: GDSCPalette.yellow1000,
+            loading: GDSCPalette.yellow1000,
+            disabled: GDSCPalette.warmGray400)),
+    secondary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.yellow300.withOpacity(0.64),
+          pressed: GDSCPalette.yellow300.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.yellow800,
+            active: GDSCPalette.yellow900,
+            pressed: GDSCPalette.yellow1000,
+            loading: GDSCPalette.yellow1000,
+            disabled: GDSCPalette.warmGray400)),
+    tertiary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.warmGray200.withOpacity(0.64),
+          pressed: GDSCPalette.warmGray200.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.warmGray800,
+            active: GDSCPalette.warmGray1000,
+            pressed: GDSCPalette.warmGray1000,
+            loading: GDSCPalette.warmGray1000,
+            disabled: GDSCPalette.warmGray400)),
+  );
+
+  static var red = _SemanticTextButtonTheme(
+    primary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.warmGray200.withOpacity(0.64),
+          pressed: GDSCPalette.warmGray200.withOpacity(0.72),
+        ),
+        label: _TextButtonLabelTheme(
+            common: GDSCPalette.red600,
+            active: GDSCPalette.red700.withOpacity(0.84),
+            pressed: GDSCPalette.red700,
+            loading: GDSCPalette.red700,
+            disabled: GDSCPalette.warmGray400)),
+    secondary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.red300.withOpacity(0.64),
+          pressed: GDSCPalette.red300.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.red500,
+            active: GDSCPalette.red600,
+            pressed: GDSCPalette.red700,
+            loading: GDSCPalette.red700,
+            disabled: GDSCPalette.warmGray400)),
+    tertiary: _TextButtonTheme(
+        background: _TextButtonBackgroundTheme(
+          active: GDSCPalette.warmGray200.withOpacity(0.64),
+          pressed: GDSCPalette.warmGray200.withOpacity(0.72),
+        ),
+        label: const _TextButtonLabelTheme(
+            common: GDSCPalette.warmGray800,
+            active: GDSCPalette.warmGray900,
+            pressed: GDSCPalette.warmGray1000,
+            loading: GDSCPalette.warmGray1000,
+            disabled: GDSCPalette.warmGray400)),
+  );
+}

--- a/lib/src/semantic/text_button.dart
+++ b/lib/src/semantic/text_button.dart
@@ -2,24 +2,24 @@ import 'dart:ui';
 
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
-class _TextButtonBackgroundTheme {
+class TextButtonBackgroundColors {
   final Color active;
   final Color pressed;
 
-  const _TextButtonBackgroundTheme({
+  const TextButtonBackgroundColors({
     required this.active,
     required this.pressed,
   });
 }
 
-class _TextButtonLabelTheme {
+class TextButtonLabelColors {
   final Color common;
   final Color active;
   final Color pressed;
   final Color loading;
   final Color disabled;
 
-  const _TextButtonLabelTheme({
+  const TextButtonLabelColors({
     required this.common,
     required this.active,
     required this.pressed,
@@ -28,57 +28,57 @@ class _TextButtonLabelTheme {
   });
 }
 
-class _TextButtonTheme {
-  final _TextButtonBackgroundTheme background;
-  final _TextButtonLabelTheme label;
+class TextButtonColors {
+  final TextButtonBackgroundColors background;
+  final TextButtonLabelColors label;
 
-  const _TextButtonTheme({
+  const TextButtonColors({
     required this.background,
     required this.label,
   });
 }
 
-class _SemanticTextButtonTheme {
-  final _TextButtonTheme primary;
-  final _TextButtonTheme secondary;
-  final _TextButtonTheme tertiary;
+class SemanticTextButtonColors {
+  final TextButtonColors primary;
+  final TextButtonColors secondary;
+  final TextButtonColors tertiary;
 
-  const _SemanticTextButtonTheme({
+  const SemanticTextButtonColors({
     required this.primary,
     required this.secondary,
     required this.tertiary,
   });
 }
 
-class GDSCTextButtonTheme {
-  static var blue = _SemanticTextButtonTheme(
-    primary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+class GDSCTextButtonColors {
+  static var blue = SemanticTextButtonColors(
+    primary: TextButtonColors(
+        background: TextButtonBackgroundColors(
             active: GDSCPalette.coolGray200.withOpacity(0.64),
             pressed: GDSCPalette.coolGray200.withOpacity(0.72)),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.blue500,
             active: GDSCPalette.blue600,
             pressed: GDSCPalette.blue700,
             loading: GDSCPalette.blue700,
             disabled: GDSCPalette.coolGray400)),
-    secondary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+    secondary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.blue300.withOpacity(0.64),
           pressed: GDSCPalette.blue300.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.blue500,
             active: GDSCPalette.blue600,
             pressed: GDSCPalette.blue700,
             loading: GDSCPalette.blue700,
             disabled: GDSCPalette.coolGray400)),
-    tertiary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+    tertiary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.coolGray200.withOpacity(0.64),
           pressed: GDSCPalette.coolGray200.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.coolGray800,
             active: GDSCPalette.coolGray900,
             pressed: GDSCPalette.coolGray1000,
@@ -86,35 +86,35 @@ class GDSCTextButtonTheme {
             disabled: GDSCPalette.coolGray400)),
   );
 
-  static var green = _SemanticTextButtonTheme(
-    primary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+  static var green = SemanticTextButtonColors(
+    primary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.coolGray200.withOpacity(0.64),
           pressed: GDSCPalette.coolGray200.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.green500,
             active: GDSCPalette.green600,
             pressed: GDSCPalette.green700,
             loading: GDSCPalette.green700,
             disabled: GDSCPalette.coolGray400)),
-    secondary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+    secondary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.green300.withOpacity(0.64),
           pressed: GDSCPalette.green300.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.green500,
             active: GDSCPalette.green600,
             pressed: GDSCPalette.green700,
             loading: GDSCPalette.green700,
             disabled: GDSCPalette.coolGray400)),
-    tertiary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+    tertiary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.coolGray200.withOpacity(0.64),
           pressed: GDSCPalette.coolGray200.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.coolGray800,
             active: GDSCPalette.coolGray900,
             pressed: GDSCPalette.coolGray1000,
@@ -122,35 +122,35 @@ class GDSCTextButtonTheme {
             disabled: GDSCPalette.coolGray400)),
   );
 
-  static var yellow = _SemanticTextButtonTheme(
-    primary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+  static var yellow = SemanticTextButtonColors(
+    primary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.warmGray200.withOpacity(0.64),
           pressed: GDSCPalette.warmGray200.withOpacity(0.64),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.yellow800,
             active: GDSCPalette.yellow900,
             pressed: GDSCPalette.yellow1000,
             loading: GDSCPalette.yellow1000,
             disabled: GDSCPalette.warmGray400)),
-    secondary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+    secondary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.yellow300.withOpacity(0.64),
           pressed: GDSCPalette.yellow300.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.yellow800,
             active: GDSCPalette.yellow900,
             pressed: GDSCPalette.yellow1000,
             loading: GDSCPalette.yellow1000,
             disabled: GDSCPalette.warmGray400)),
-    tertiary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+    tertiary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.warmGray200.withOpacity(0.64),
           pressed: GDSCPalette.warmGray200.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.warmGray800,
             active: GDSCPalette.warmGray1000,
             pressed: GDSCPalette.warmGray1000,
@@ -158,35 +158,35 @@ class GDSCTextButtonTheme {
             disabled: GDSCPalette.warmGray400)),
   );
 
-  static var red = _SemanticTextButtonTheme(
-    primary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+  static var red = SemanticTextButtonColors(
+    primary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.warmGray200.withOpacity(0.64),
           pressed: GDSCPalette.warmGray200.withOpacity(0.72),
         ),
-        label: _TextButtonLabelTheme(
+        label: TextButtonLabelColors(
             common: GDSCPalette.red600,
             active: GDSCPalette.red700.withOpacity(0.84),
             pressed: GDSCPalette.red700,
             loading: GDSCPalette.red700,
             disabled: GDSCPalette.warmGray400)),
-    secondary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+    secondary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.red300.withOpacity(0.64),
           pressed: GDSCPalette.red300.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.red500,
             active: GDSCPalette.red600,
             pressed: GDSCPalette.red700,
             loading: GDSCPalette.red700,
             disabled: GDSCPalette.warmGray400)),
-    tertiary: _TextButtonTheme(
-        background: _TextButtonBackgroundTheme(
+    tertiary: TextButtonColors(
+        background: TextButtonBackgroundColors(
           active: GDSCPalette.warmGray200.withOpacity(0.64),
           pressed: GDSCPalette.warmGray200.withOpacity(0.72),
         ),
-        label: const _TextButtonLabelTheme(
+        label: const TextButtonLabelColors(
             common: GDSCPalette.warmGray800,
             active: GDSCPalette.warmGray900,
             pressed: GDSCPalette.warmGray1000,

--- a/lib/src/theme/color_scheme.dart
+++ b/lib/src/theme/color_scheme.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gdsc_ys_color/gdsc_ys_color.dart';
 
+/// Predefined color schemes for GDSC-ys-colors
 class GDSCColorScheme {
   static ColorScheme blue = const ColorScheme.light(
     primary: GDSCPalette.blue500,

--- a/lib/src/theme/color_scheme.dart
+++ b/lib/src/theme/color_scheme.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:gdsc_ys_color/gdsc_ys_color.dart';
+
+class GDSCColorScheme {
+  static ColorScheme blue = const ColorScheme.light(
+    primary: GDSCPalette.blue500,
+    onPrimary: GDSCPalette.white,
+    secondary: GDSCPalette.blue300,
+    onSecondary: GDSCPalette.blue900,
+    tertiary: GDSCPalette.coolGray200,
+    onTertiary: GDSCPalette.coolGray700,
+    background: GDSCPalette.white,
+    surface: GDSCPalette.white,
+    outline: GDSCPalette.coolGray400,
+  );
+
+  static ColorScheme green = const ColorScheme.light(
+    primary: GDSCPalette.green500,
+    onPrimary: GDSCPalette.white,
+    secondary: GDSCPalette.green300,
+    onSecondary: GDSCPalette.green900,
+    tertiary: GDSCPalette.coolGray200,
+    onTertiary: GDSCPalette.coolGray700,
+    background: GDSCPalette.white,
+    surface: GDSCPalette.white,
+    outline: GDSCPalette.coolGray500,
+  );
+
+  static ColorScheme yellow = const ColorScheme.light(
+    primary: GDSCPalette.yellow800,
+    onPrimary: GDSCPalette.white,
+    secondary: GDSCPalette.yellow300,
+    onSecondary: GDSCPalette.yellow1000,
+    tertiary: GDSCPalette.warmGray200,
+    onTertiary: GDSCPalette.warmGray700,
+    background: GDSCPalette.white,
+    surface: GDSCPalette.white,
+    outline: GDSCPalette.warmGray400,
+  );
+
+  static ColorScheme red = const ColorScheme.light(
+    primary: GDSCPalette.red600,
+    onPrimary: GDSCPalette.white,
+    secondary: GDSCPalette.red300,
+    onSecondary: GDSCPalette.red900,
+    tertiary: GDSCPalette.warmGray200,
+    onTertiary: GDSCPalette.warmGray700,
+    background: GDSCPalette.white,
+    surface: GDSCPalette.white,
+    outline: GDSCPalette.warmGray400,
+  );
+}

--- a/lib/src/theme/index.dart
+++ b/lib/src/theme/index.dart
@@ -1,0 +1,2 @@
+export 'theme.dart';
+export 'color_scheme.dart';

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -12,25 +12,29 @@ class GDSCTheme {
   SemanticColors get colors =>
       _semanticColors.getColor();
 
-  set theme(GDSCColorTheme theme) {
+  set current(GDSCColorTheme theme) {
     currentTheme = theme;
     _semanticColors = GDSCSemanticColors(currentTheme: currentTheme);
   }
 
   static final ThemeData blue = ThemeData(
     colorScheme: GDSCColorScheme.blue,
+    primaryColor: GDSCColorScheme.blue.primary,
   );
 
   static final ThemeData green = ThemeData(
     colorScheme: GDSCColorScheme.green,
+    primaryColor: GDSCColorScheme.green.primary,
   );
 
   static final ThemeData yellow = ThemeData(
     colorScheme: GDSCColorScheme.yellow,
+    primaryColor: GDSCColorScheme.yellow.primary,
   );
 
   static final ThemeData red = ThemeData(
     colorScheme: GDSCColorScheme.red,
+    primaryColor: GDSCColorScheme.red.primary,
   );
 
   ThemeData getTheme() {

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -1,17 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:gdsc_ys_color/src/semantic/index.dart';
 
+import '../content/index.dart';
 import 'color_scheme.dart';
 import '../enum/index.dart';
 
 class GDSCTheme {
 
   GDSCColorTheme _currentTheme;
+  final _contentColors = GDSCContentColors();
   late SemanticColors _colors;
 
   /// Semantic Colors
   /// returns the semantic colors of the current theme
   SemanticColors get colors => _colors;
+
+  /// Content Colors
+  /// returns the content colors of the current theme
+  GDSCContentColors get contentColors => _contentColors;
 
   /// Changes the current theme
   set current(GDSCColorTheme theme) {

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -6,15 +6,17 @@ import '../enum/index.dart';
 
 class GDSCTheme {
 
-  GDSCColorTheme currentTheme;
-  late GDSCSemanticColors _semanticColors;
+  GDSCColorTheme _currentTheme;
+  late SemanticColors _colors;
 
-  SemanticColors get colors =>
-      _semanticColors.getColor();
+  /// Semantic Colors
+  /// returns the semantic colors of the current theme
+  SemanticColors get colors => _colors;
 
+  /// Changes the current theme
   set current(GDSCColorTheme theme) {
-    currentTheme = theme;
-    _semanticColors = GDSCSemanticColors(currentTheme: currentTheme);
+    _currentTheme = theme;
+    _colors = GDSCSemanticColors(currentTheme: _currentTheme).colors;
   }
 
   static final ThemeData blue = ThemeData(
@@ -37,8 +39,9 @@ class GDSCTheme {
     primaryColor: GDSCColorScheme.red.primary,
   );
 
+  /// Returns the current theme's themeData
   ThemeData getTheme() {
-    switch (currentTheme) {
+    switch (_currentTheme) {
       case GDSCColorTheme.blue:
         return blue;
       case GDSCColorTheme.green:
@@ -50,7 +53,7 @@ class GDSCTheme {
     }
   }
 
-  GDSCTheme({this.currentTheme = GDSCColorTheme.blue}) {
-    _semanticColors = GDSCSemanticColors(currentTheme: currentTheme);
+  GDSCTheme({GDSCColorTheme currentTheme = GDSCColorTheme.blue}) : _currentTheme = currentTheme {
+    _colors = GDSCSemanticColors(currentTheme: _currentTheme).colors;
   }
 }

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -1,23 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:gdsc_ys_color/src/semantic/index.dart';
 
-import '../content/index.dart';
 import 'color_scheme.dart';
 import '../enum/index.dart';
 
 class GDSCTheme {
-
   GDSCColorTheme _currentTheme;
-  final _contentColors = GDSCContentColors();
   late SemanticColors _colors;
 
   /// Semantic Colors
   /// returns the semantic colors of the current theme
   SemanticColors get colors => _colors;
-
-  /// Content Colors
-  /// returns the content colors of the current theme
-  GDSCContentColors get contentColors => _contentColors;
 
   /// Changes the current theme
   set current(GDSCColorTheme theme) {
@@ -59,7 +52,8 @@ class GDSCTheme {
     }
   }
 
-  GDSCTheme({required GDSCColorTheme currentTheme}) : _currentTheme = currentTheme {
+  GDSCTheme({required GDSCColorTheme currentTheme})
+      : _currentTheme = currentTheme {
     _colors = GDSCSemanticColors(currentTheme: _currentTheme).colors;
   }
 }

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:gdsc_ys_color/src/semantic/index.dart';
+
+import 'color_scheme.dart';
+import '../enum/index.dart';
+
+class GDSCTheme {
+  // default theme is set to blue.
+  GDSCColorTheme currentTheme;
+  late GDSCSemanticColor _colors;
+
+  GDSCSemanticColor get colors =>
+      _colors;
+
+  set theme(GDSCColorTheme theme) {
+    currentTheme = theme;
+    _colors = GDSCSemanticColor(currentTheme: currentTheme);
+  }
+
+  static final ThemeData blue = ThemeData(
+    colorScheme: GDSCColorScheme.blue,
+  );
+
+  static final ThemeData green = ThemeData(
+    colorScheme: GDSCColorScheme.green,
+  );
+
+  static final ThemeData yellow = ThemeData(
+    colorScheme: GDSCColorScheme.yellow,
+  );
+
+  static final ThemeData red = ThemeData(
+    colorScheme: GDSCColorScheme.red,
+  );
+
+  ThemeData getTheme() {
+    switch (currentTheme) {
+      case GDSCColorTheme.blue:
+        return blue;
+      case GDSCColorTheme.green:
+        return green;
+      case GDSCColorTheme.yellow:
+        return yellow;
+      case GDSCColorTheme.red:
+        return red;
+    }
+  }
+
+  GDSCTheme({
+    required this.currentTheme,
+  });
+}

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -53,7 +53,7 @@ class GDSCTheme {
     }
   }
 
-  GDSCTheme({GDSCColorTheme currentTheme = GDSCColorTheme.blue}) : _currentTheme = currentTheme {
+  GDSCTheme({required GDSCColorTheme currentTheme}) : _currentTheme = currentTheme {
     _colors = GDSCSemanticColors(currentTheme: _currentTheme).colors;
   }
 }

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -5,16 +5,16 @@ import 'color_scheme.dart';
 import '../enum/index.dart';
 
 class GDSCTheme {
-  // default theme is set to blue.
-  GDSCColorTheme currentTheme;
-  late GDSCSemanticColor _colors;
 
-  GDSCSemanticColor get colors =>
-      _colors;
+  GDSCColorTheme currentTheme;
+  late GDSCSemanticColors _semanticColors;
+
+  SemanticColors get colors =>
+      _semanticColors.getColor();
 
   set theme(GDSCColorTheme theme) {
     currentTheme = theme;
-    _colors = GDSCSemanticColor(currentTheme: currentTheme);
+    _semanticColors = GDSCSemanticColors(currentTheme: currentTheme);
   }
 
   static final ThemeData blue = ThemeData(
@@ -46,7 +46,7 @@ class GDSCTheme {
     }
   }
 
-  GDSCTheme({
-    required this.currentTheme,
-  });
+  GDSCTheme({this.currentTheme = GDSCColorTheme.blue}) {
+    _semanticColors = GDSCSemanticColors(currentTheme: currentTheme);
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,14 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.2"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.6"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
## 완성된 사항

주어진 테마를 완성하였습니다.

라이브러리에서 export하는 객체들은 아래와 같습니다.
- `GDSCTheme` : GDSC의 테마 정보를 담은 클래스.
- `GDSCColorTheme` : GDSC 테마 색상을 지정하는 enum
- `GDSCPalette` : GDSC 팔레트

`GDSCTheme` 클래스의 인스턴스에서 `colors` 를 통해 현재 테마에 맞는 시맨틱 컬러에 접근할 수 있습니다. (`useSemanticColor` 와 동일)

또한 Example에서 테마 변경하는 예제를 작성하였습니다.

https://github.com/gdsc-ys/color-flutter/assets/75557859/4588e372-5696-4959-952c-7eebf2bd257d

## 추후 보완되어야 할 사항

- tint Color 추가
- Flutter의 경우 Material Component의 테마까지 세부적으로 조정이 가능한데, GDSC theme과 네이밍 등의 방식에 차이가 있어 우선 `colorScheme` 을 이용하여 기본적인 테마 반영만 한 상태라 반영이 필요합니다.
- 테마 변경이 완전하지 않음 : 최종적으로는 MaterialApp에서 `Theme.of(Context)` 로 Theme이 바뀔 때마다 Context도 바뀌도록 해야 하는데, 이것을 라이브러리 단에서 스위칭할 수 있게 지원할 것인지 아니면 example에 사용 예시로 추가할 것인지에 대해서는 고민이 필요합니다.